### PR TITLE
fix segfault

### DIFF
--- a/filewatcher.c
+++ b/filewatcher.c
@@ -38,10 +38,10 @@ extern bool verbose;
 int main(int argc, char** argv) {
     signal(SIGINT, shutDown);
 
-    banner();
     output = OUT;
     error = ERR;
     debug = OFF;
+    banner();
 
     if(!isRoot()) {
         fprintf(output, "This software must be run as root.\n");


### PR DESCRIPTION
Hello!

The program segfaults with 'Segmentation fault: 11'.

This is because `banner()` is called before `output` is initialized. Therefore move the call down after the initialization.