### PR TITLE
Fixed segmentation fault error

### DIFF
--- a/lib/auditing.c
+++ b/lib/auditing.c
@@ -38,6 +38,7 @@ tokenstr_t token;
 
 struct auditEvent getEvent(FILE* auditFile) {
     struct auditEvent curr;
+    memset(&curr, 0, sizeof(curr));
 
     recordLength = au_read_rec(auditFile, &buffer);
     if (recordLength == -1) {

--- a/lib/common.c
+++ b/lib/common.c
@@ -53,7 +53,7 @@ char* getPathArg(char * path, int value){
     // I want last token, no need to use strtok()
     if (value == 0) {
         segment = strrchr(path, '/');
-        segment = segment+1;
+        segment = (segment)?(segment+1):"";
     }
     else {
         // I want paramenter number value, using strtok()


### PR DESCRIPTION
Initialized 'curr'  and checked pointer('segment') before accessing it to avoid segmentation fault error.